### PR TITLE
fix: provided an up-to-date phone mask for Guinea (GN)

### DIFF
--- a/lib/constants/countries.js
+++ b/lib/constants/countries.js
@@ -2492,7 +2492,7 @@ export const countries = [
       ua: 'Гвінея',
       zh: '幾內亞',
     },
-    phoneMasks: ['## ### ###'],
+    phoneMasks: ['### ## ## ##'],
   },
   {
     callingCode: '+590',


### PR DESCRIPTION
The phone numbers in Guinea switched from eight to nine digits since March 31, 2013.